### PR TITLE
Ensure routing package importable

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/routing/__init__.py
+++ b/routing/__init__.py
@@ -1,0 +1,1 @@
+"""Initialize routing package for tests."""


### PR DESCRIPTION
## Summary
- add missing package initializer for `routing`
- configure pytest to include project root on import path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3a5598d9c8327b78cb46c86f25a15